### PR TITLE
Migrate Nim runtime to StarIntel v0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - "agent/**"
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: stable
+      - run: nimble install -y
+      - run: nimble test -y

--- a/SCHEMA_ORG_V09.md
+++ b/SCHEMA_ORG_V09.md
@@ -1,0 +1,17 @@
+# StarIntel Nim v0.9
+
+The Nim runtime preserves the current object constructors while `dump()` emits the canonical StarIntel v0.9 envelope.
+
+Subtype object fields are nested beneath `data`; timestamps are ISO-8601 strings; record versions are integers; string source values become structured source records; and every document receives a declared `schema_org` JSON-LD block.
+
+```nim
+var organization = newOrg("Example Org", "company")
+organization.dataset = "example"
+let wire = organization.dump
+
+doAssert wire["schema_version"].getStr == "0.9.0"
+doAssert wire["data"]["name"].getStr == "Example Org"
+doAssert wire["schema_org"]["@type"].getStr == "Organization"
+```
+
+`load()` accepts the canonical nested wire representation and restores the legacy-compatible subtype object fields.

--- a/src/starintel_doc.nim
+++ b/src/starintel_doc.nim
@@ -1,5 +1,4 @@
-import starintel_doc/[documents, entities, locations, phones, web, targets, relation, social_media, hosts]
-export documents, entities, locations, phones, web, targets, relation, social_media, hosts
-
+import starintel_doc/[documents, entities, locations, phones, web, targets, relation, social_media, hosts, schema_org]
+export documents, entities, locations, phones, web, targets, relation, social_media, hosts, schema_org
 
 # TODO update or move import starintel_doc/utils/doc_parsing

--- a/src/starintel_doc/documents.nim
+++ b/src/starintel_doc/documents.nim
@@ -1,107 +1,197 @@
-import std/[hashes, md5, sha1, strutils]
+import std/[hashes, json, md5, sha1, strutils, times, typetraits]
 import ulid
-from times import getTime, toUnix
-export getTime, toUnix
-import json
-import typetraits
+import schema_org
 
-#any changes requires this to be bumped
-const DOC_VERSION* = "0.7.3"
+export getTime, toUnix
+export schema_org
+
+const DOC_VERSION* = "0.9.0"
 
 type
-    Document* = ref object of RootObj
-        ## Base Object to hold the document metadata thats used to make a dcoument and store it in the database.
-        id*: string
-        dataset*: string
-        dtype*: string
-        date_added*: int64
-        date_updated*: int64
-        version*: string = DOC_VERSION
-        sources*: seq[string]
+  Document* = ref object of RootObj
+    ## Canonical StarIntel v0.9 envelope. Subtype fields are nested under data by dump().
+    id*: string
+    rev*: string
+    dataset*: string
+    dtype*: string
+    schema_version*: string = DOC_VERSION
+    version*: int = 1
+    date_added*: string
+    date_updated*: string
+    title*: string
+    summary*: string
+    description*: string
+    status*: string
+    language*: string
+    tags*: seq[string]
+    labels*: seq[string]
+    aliases*: seq[string]
+    keywords*: seq[string]
+    identifiers*: seq[JsonNode]
+    sources*: seq[string]
+    evidence*: seq[JsonNode]
+    temporal*: JsonNode
+    provenance*: JsonNode
+    assessment*: JsonNode
+    verification*: JsonNode
+    handling*: JsonNode
+    lineage*: JsonNode
+    quality*: JsonNode
+    workflow*: JsonNode
+    geospatial*: JsonNode
+    attachments*: seq[JsonNode]
+    related_ids*: seq[string]
+    notes*: seq[string]
+    schema_org*: JsonNode
+    data*: JsonNode
+    extensions*: JsonNode
 
-template link*[T, V](doc: T, field: untyped, data: V) =
-    field.add(data)
+template link*[T, V](doc: T, field: untyped, value: V) =
+  field.add(value)
 
+proc utcNow*(): string =
+  now().utc.format("yyyy-MM-dd'T'HH:mm:ss'.'fff'Z'")
 
+proc ensureObject(node: var JsonNode) =
+  if node.isNil or node.kind != JObject:
+    node = newJObject()
 
 template makeUUID*[T](doc: T) =
-    ## Generate a UUID for a document
-    doc.id = ulid()
+  doc.id = ulid()
 
-# TODO remove this
-# template makeEID*[T](doc: T, data: string) =
-#     ## Generate a EID
-#     ## for data include enough data to make it unique
-#     ## For example for a person; first name, middle name, last name can be used
-#     doc.eid = makeHash(data)
+# Compatibility helpers retained for existing callers.
+template makeMD5ID*[T](doc: T, value: string) =
+  doc.id = $toMD5(value)
 
-# TODO setId
-# overload for each type
-
-template makeMD5ID*[T](doc: T, data: string) =
-    ## Generate a MD5 checksum for the document id
-    doc.id = $toMD5(data)
-
-
-template makeSHAID*[T](doc: T, data: string) =
-    ## Generate a SHA1 checksume for the document ID
-    doc.id = $secureHash(data)
-
+template makeSHAID*[T](doc: T, value: string) =
+  doc.id = $secureHash(value)
 
 template timestamp*[T](doc: T) =
-    ## Add a timestamp to the document
-    ## Not done in helpers because sometimes you want the time from the data source
-    let t = getTime()
-    doc.date_added = t.toUnix()
-    doc.date_updated = t.toUnix()
-
+  let stamp = utcNow()
+  doc.date_added = stamp
+  doc.date_updated = stamp
 
 template updateTime*[T](doc: T) =
-    ## update the date_updated timestamp to the document
-    let t = getTime()
-    doc.date_updated = t.toUnix()
-
+  doc.date_updated = utcNow()
+  doc.version = max(1, doc.version) + 1
 
 template setType*[T](doc: T) =
-    doc.dtype = toLowerAscii($typeOf(doc))
+  var typeName = $typeOf(doc)
+  if typeName.startsWith("ref "):
+    typeName = typeName[4 .. ^1]
+  doc.dtype = canonicalDtype(typeName)
+
+proc ensureSchemaOrg*[T](doc: T) =
+  let defaults = schemaOrgMetadata(doc.dtype, doc.id)
+  if doc.schema_org.isNil or doc.schema_org.kind != JObject:
+    doc.schema_org = defaults
+  else:
+    for key, value in defaults.pairs:
+      if key == "@id" or not doc.schema_org.hasKey(key):
+        doc.schema_org[key] = value
 
 template setMeta*[T](doc: T, docDataset: string = "star-intel") =
-    ## Add Metadata to the document
-    ## if a field is set, it will not set it.
-    ## If the dataset is missing, it will set default from `dataset` argument.
-    let t = getTime()
-    doc.setType
-    if doc.date_added == 0:
-        doc.date_added = t.toUnix()
-    if doc.date_updated == 0:
-        doc.date_updated = t.toUnix()
-    if doc.id.len == 0:
-        doc.makeUUID
-    if doc.dataset.len == 0:
-        doc.dataset = docDataset
+  doc.setType
+  if doc.date_added.len == 0 or doc.date_updated.len == 0:
+    doc.timestamp
+  if doc.id.len == 0:
+    doc.makeUUID
+  if doc.dataset.len == 0:
+    doc.dataset = docDataset
+  doc.schema_version = DOC_VERSION
+  if doc.version < 1:
+    doc.version = 1
+  if doc.status.len == 0:
+    doc.status = "recorded"
+  if doc.language.len == 0:
+    doc.language = "en"
+  ensureObject(doc.temporal)
+  ensureObject(doc.provenance)
+  ensureObject(doc.assessment)
+  ensureObject(doc.verification)
+  if not doc.verification.hasKey("status"):
+    doc.verification["status"] = %"unverified"
+  if not doc.verification.hasKey("verified"):
+    doc.verification["verified"] = %false
+  ensureObject(doc.handling)
+  if not doc.handling.hasKey("visibility"):
+    doc.handling["visibility"] = %"public"
+  if not doc.handling.hasKey("sensitive"):
+    doc.handling["sensitive"] = %false
+  if not doc.handling.hasKey("pii"):
+    doc.handling["pii"] = %false
+  ensureObject(doc.lineage)
+  ensureObject(doc.quality)
+  ensureObject(doc.workflow)
+  ensureObject(doc.geospatial)
+  ensureObject(doc.data)
+  ensureObject(doc.extensions)
+  doc.ensureSchemaOrg
 
-proc addSource*[T](doc: T, tag: string) =
-    ## Adds a tag to the document.
-    doc.sources.add(tag)
+proc addSource*[T](doc: T, source: string) =
+  doc.sources.add(source)
+
+proc isEnvelopeKey(key: string): bool =
+  key in [
+    "dataset", "dtype", "schema_version", "version", "date_added", "date_updated",
+    "title", "summary", "description", "status", "language", "tags", "labels",
+    "aliases", "keywords", "identifiers", "evidence", "temporal", "provenance",
+    "assessment", "verification", "handling", "lineage", "quality", "workflow",
+    "geospatial", "attachments", "related_ids", "notes", "schema_org", "extensions"
+  ]
+
+proc structuredSources(values: seq[string]): JsonNode =
+  result = newJArray()
+  for source in values:
+    result.add(%*{
+      "kind": "web",
+      "name": source,
+      "uri": source,
+      "url": source
+    })
 
 proc dump*[T](doc: T): JsonNode =
-    ## Dump a document to json, This is only needed since couchdb uses _id as the id.
-    var jdoc = %*doc
-    jdoc{"_id"} = newJString(doc.id)
-    jdoc.delete("id")
-    result = jdoc
+  ## Emit the canonical v0.9 wire object while preserving legacy subtype APIs.
+  doc.setMeta(if doc.dataset.len > 0: doc.dataset else: "star-intel")
+  let raw = %*doc
+  result = newJObject()
+  var subtypeData = if doc.data.isNil or doc.data.kind != JObject: newJObject() else: doc.data
 
+  for key, value in raw.pairs:
+    case key
+    of "id":
+      result["_id"] = value
+    of "rev":
+      if value.kind == JString and value.getStr.len > 0:
+        result["_rev"] = value
+    of "sources":
+      result["sources"] = structuredSources(doc.sources)
+    of "data":
+      discard
+    else:
+      if isEnvelopeKey(key):
+        result[key] = value
+      else:
+        subtypeData[key] = value
+
+  result["data"] = subtypeData
 
 proc load*[T](node: JsonNode, t: typedesc[T]): T =
-    ## Loads a document from json, This is only needed since couchdb uses _id as the id.
-    var jdoc = node
-    jdoc{"id"} = jdoc["_id"]
-    jdoc{"rev"} = jdoc["_rev"]
-    result = jdoc.to(t)
-
-
+  ## Load canonical v0.9 JSON into the legacy-compatible Nim object hierarchy.
+  var flattened = node
+  if flattened.hasKey("_id"):
+    flattened["id"] = flattened["_id"]
+    flattened.delete("_id")
+  if flattened.hasKey("_rev"):
+    flattened["rev"] = flattened["_rev"]
+    flattened.delete("_rev")
+  if flattened.hasKey("data") and flattened["data"].kind == JObject:
+    for key, value in flattened["data"].pairs:
+      flattened[key] = value
+  result = flattened.to(t)
+  result.setMeta(if result.dataset.len > 0: result.dataset else: "star-intel")
 
 when isMainModule:
-    var doc = Document()
-    doc.setType()
-    echo doc.dump
+  var doc = Document()
+  doc.setMeta()
+  echo doc.dump

--- a/src/starintel_doc/documents.nim
+++ b/src/starintel_doc/documents.nim
@@ -150,6 +150,62 @@ proc structuredSources(values: seq[string]): JsonNode =
       "url": source
     })
 
+proc wireDataKey(key: string): string =
+  case key
+  of "fromF", "from_":
+    return "from"
+  of "resolved":
+    return "resolved_addresses"
+  else:
+    discard
+
+  for index, character in key:
+    if character.isUpperAscii:
+      if index > 0:
+        result.add('_')
+      result.add(character.toLowerAscii)
+    else:
+      result.add(character)
+
+proc stringField(data: JsonNode, key: string): string =
+  if data.kind == JObject and data.hasKey(key) and data[key].kind == JString:
+    data[key].getStr
+  else:
+    ""
+
+proc normalizeRequiredData(dtype: string, data: var JsonNode) =
+  case dtype
+  of "relation":
+    if not data.hasKey("subject"):
+      data["subject"] = %stringField(data, "source")
+    if not data.hasKey("object"):
+      data["object"] = %stringField(data, "target")
+    if not data.hasKey("predicate") or stringField(data, "predicate").len == 0:
+      data["predicate"] = %"related_to"
+  of "domain":
+    if not data.hasKey("domain"):
+      data["domain"] = %stringField(data, "record")
+  of "email":
+    if not data.hasKey("address"):
+      let user = stringField(data, "user")
+      let domain = stringField(data, "domain")
+      data["address"] = %(if user.len > 0 and domain.len > 0: user & "@" & domain else: "")
+  of "email-message":
+    if data.hasKey("to") and data["to"].kind == JString:
+      let recipient = data["to"].getStr
+      var recipients = newJArray()
+      if recipient.len > 0:
+        recipients.add(%recipient)
+      data["to"] = recipients
+    if data.hasKey("headers") and data["headers"].kind == JString:
+      let raw = data["headers"].getStr
+      var headers = newJObject()
+      if raw.len > 0:
+        headers["raw"] = %raw
+      data["headers"] = headers
+  else:
+    discard
+
 proc dump*[T](doc: T): JsonNode =
   ## Emit the canonical v0.9 wire object while preserving legacy subtype APIs.
   doc.setMeta(if doc.dataset.len > 0: doc.dataset else: "star-intel")
@@ -172,8 +228,9 @@ proc dump*[T](doc: T): JsonNode =
       if isEnvelopeKey(key):
         result[key] = value
       else:
-        subtypeData[key] = value
+        subtypeData[wireDataKey(key)] = value
 
+  normalizeRequiredData(doc.dtype, subtypeData)
   result["data"] = subtypeData
 
 proc load*[T](node: JsonNode, t: typedesc[T]): T =

--- a/src/starintel_doc/documents.nim
+++ b/src/starintel_doc/documents.nim
@@ -178,13 +178,24 @@ proc dump*[T](doc: T): JsonNode =
 
 proc load*[T](node: JsonNode, t: typedesc[T]): T =
   ## Load canonical v0.9 JSON into the legacy-compatible Nim object hierarchy.
-  var flattened = node
+  var flattened = parseJson($node)
   if flattened.hasKey("_id"):
     flattened["id"] = flattened["_id"]
     flattened.delete("_id")
   if flattened.hasKey("_rev"):
     flattened["rev"] = flattened["_rev"]
     flattened.delete("_rev")
+  if flattened.hasKey("sources") and flattened["sources"].kind == JArray:
+    var legacySources = newJArray()
+    for source in flattened["sources"].items:
+      if source.kind == JString:
+        legacySources.add(source)
+      elif source.kind == JObject:
+        if source.hasKey("url") and source["url"].kind == JString:
+          legacySources.add(source["url"])
+        elif source.hasKey("uri") and source["uri"].kind == JString:
+          legacySources.add(source["uri"])
+    flattened["sources"] = legacySources
   if flattened.hasKey("data") and flattened["data"].kind == JObject:
     for key, value in flattened["data"].pairs:
       flattened[key] = value

--- a/src/starintel_doc/relation.nim
+++ b/src/starintel_doc/relation.nim
@@ -1,24 +1,27 @@
 import documents
-type Relation* = ref object of Document
-  ## A object that represents a relationship between two entities
-  source*: string
-  ## The ID of the source entity
-  target*: string
-  ## The ID of the target entity
-  note*: string
-  ## Note
-proc newRelation*(source, target: string, note: string = "", dataset: string): Relation =
-  ## Creates a new `Relation` object with the specified `source`, `target`, and `note` values
-  ##
-  ## Parameters:
-  ##   source (string): The ID of the source entity
-  ##   target (string): The ID of the target entity
-  ##   relation (Relations): The type of the relationship
-  ##
-  ## Returns:
-  ##   Relation: The newly created `Relation` object
-  var doc = Relation(source: source, target: target, note: note)
-  doc.makeUUID
-  doc.timeStamp()
-  result = doc
 
+type Relation* = ref object of Document
+  ## A relationship between two StarIntel entities.
+  source*: string
+  target*: string
+  predicate*: string
+  note*: string
+
+proc newRelation*(
+  source, target: string,
+  predicate: string = "related_to",
+  note: string = "",
+  dataset: string = "star-intel"
+): Relation =
+  ## Create a canonical relation while preserving the legacy source/target API.
+  result = Relation(
+    source: source,
+    target: target,
+    predicate: predicate,
+    note: note,
+    dataset: dataset,
+    dtype: "relation"
+  )
+  result.makeUUID
+  result.timestamp
+  result.setMeta(dataset)

--- a/src/starintel_doc/schema_org.nim
+++ b/src/starintel_doc/schema_org.nim
@@ -1,0 +1,148 @@
+import std/[json, strutils]
+
+const SchemaOrgContext* = "https://schema.org/"
+
+const CanonicalDtypes* = [
+  "actor-manifest", "address", "alert", "analysis", "asset", "breach",
+  "campaign-finance", "claim", "concept", "contract", "dataset-manifest",
+  "document", "domain", "education", "email", "email-message", "employment",
+  "entity", "event", "evidence-record", "file", "financial-observation", "geo",
+  "grant", "host", "investigation-target", "legal-case", "lobbying-filing",
+  "location", "media", "meeting", "message", "network", "observation", "org",
+  "ownership", "person", "phone", "policy", "procurement", "product", "relation",
+  "research-pass", "social-media-post", "source", "target", "task", "url", "user"
+]
+
+proc canonicalDtype*(dtype: string): string =
+  let key = dtype.strip.toLowerAscii.replace("_", "-").replace(" ", "-")
+  case key
+  of "organization", "organisation": "org"
+  of "geolocation", "geographic-location": "geo"
+  of "email-address", "electronic-mail": "email"
+  of "emailmessage": "email-message"
+  of "hostname": "host"
+  of "phone-number", "telephone", "telephone-number": "phone"
+  of "uniform-resource-locator", "web-url": "url"
+  of "socialmpost", "socialmediapost": "social-media-post"
+  of "investigationtarget": "investigation-target"
+  of "researchpass": "research-pass"
+  of "datasetmanifest": "dataset-manifest"
+  of "actormanifest": "actor-manifest"
+  of "legalcase": "legal-case"
+  of "lobbyingfiling": "lobbying-filing"
+  of "campaignfinance": "campaign-finance"
+  of "financialobservation": "financial-observation"
+  of "evidencerecord": "evidence-record"
+  else: key
+
+proc schemaOrgType*(dtype: string): string =
+  case canonicalDtype(dtype)
+  of "actor-manifest": "CreativeWork"
+  of "address": "PostalAddress"
+  of "alert": "SpecialAnnouncement"
+  of "analysis": "CreativeWork"
+  of "asset": "Thing"
+  of "breach": "Event"
+  of "campaign-finance": "CreativeWork"
+  of "claim": "Claim"
+  of "concept": "DefinedTerm"
+  of "contract": "DigitalDocument"
+  of "dataset-manifest": "Dataset"
+  of "document": "CreativeWork"
+  of "domain": "WebSite"
+  of "education": "EducationalOccupationalCredential"
+  of "email": "ContactPoint"
+  of "email-message": "Message"
+  of "employment": "OrganizationRole"
+  of "entity": "Thing"
+  of "event": "Event"
+  of "evidence-record": "CreativeWork"
+  of "file": "DigitalDocument"
+  of "financial-observation": "CreativeWork"
+  of "geo": "GeoCoordinates"
+  of "grant": "Grant"
+  of "host": "Thing"
+  of "investigation-target": "Thing"
+  of "legal-case": "CreativeWork"
+  of "lobbying-filing": "DigitalDocument"
+  of "location": "Place"
+  of "media": "MediaObject"
+  of "meeting": "Event"
+  of "message": "Message"
+  of "network": "Thing"
+  of "observation": "CreativeWork"
+  of "org": "Organization"
+  of "ownership": "Role"
+  of "person": "Person"
+  of "phone": "ContactPoint"
+  of "policy": "CreativeWork"
+  of "procurement": "DigitalDocument"
+  of "product": "Product"
+  of "relation": "Role"
+  of "research-pass": "CreativeWork"
+  of "social-media-post": "SocialMediaPosting"
+  of "source": "CreativeWork"
+  of "target": "Thing"
+  of "task": "Action"
+  of "url": "WebPage"
+  of "user": "Person"
+  else: "Thing"
+
+proc schemaOrgMetadata*(dtype: string, documentId = ""): JsonNode =
+  let canonical = canonicalDtype(dtype)
+  result = %*{
+    "@context": SchemaOrgContext,
+    "@type": schemaOrgType(canonical),
+    "additionalType": "https://starintel.dev/dtype/" & canonical
+  }
+  if documentId.len > 0:
+    result["@id"] = %documentId
+
+proc stringValue(node: JsonNode, key: string): string =
+  if node.kind == JObject and node.hasKey(key) and node[key].kind == JString:
+    node[key].getStr
+  else:
+    ""
+
+proc toSchemaOrg*(document: JsonNode): JsonNode =
+  let dtype = stringValue(document, "dtype")
+  let documentId = stringValue(document, "_id")
+  result = schemaOrgMetadata(dtype, documentId)
+  let data = if document.kind == JObject and document.hasKey("data") and document["data"].kind == JObject:
+      document["data"]
+    else:
+      newJObject()
+
+  var name = stringValue(document, "title")
+  if name.len == 0:
+    for key in ["display_name", "full_name", "legal_name", "name", "claim", "term", "target"]:
+      name = stringValue(data, key)
+      if name.len > 0: break
+  if name.len == 0: name = documentId
+  result["name"] = %name
+
+  var description = stringValue(document, "description")
+  if description.len == 0: description = stringValue(document, "summary")
+  if description.len == 0: description = stringValue(data, "description")
+  if description.len > 0: result["description"] = %description
+
+  let language = stringValue(document, "language")
+  if language.len > 0: result["inLanguage"] = %language
+  let dateAdded = stringValue(document, "date_added")
+  if dateAdded.len > 0: result["dateCreated"] = %dateAdded
+  let dateUpdated = stringValue(document, "date_updated")
+  if dateUpdated.len > 0: result["dateModified"] = %dateUpdated
+
+  var url = stringValue(data, "url")
+  if url.len == 0: url = stringValue(data, "website")
+  if url.len == 0: url = stringValue(data, "uri")
+  if url.len > 0: result["url"] = %url
+
+  if document.kind == JObject and document.hasKey("schema_org") and document["schema_org"].kind == JObject:
+    for key, value in document["schema_org"].pairs:
+      result[key] = value
+
+static:
+  doAssert CanonicalDtypes.len == 49
+  for dtype in CanonicalDtypes:
+    doAssert schemaOrgType(dtype) != ""

--- a/starintel_doc.nimble
+++ b/starintel_doc.nimble
@@ -1,12 +1,16 @@
 # Package
 
-version = "0.7.3"
+version     = "0.9.0"
 author      = "nsaspy"
-description = "Parse and handle starintel docs"
-license     = "MIT"
-srcDir       = "src"
+description = "Canonical Nim runtime for StarIntel document schema v0.9.0"
+license     = "GPL-3.0-or-later"
+srcDir      = "src"
+
 # Deps
 
 requires "nim >= 2.0.0"
 requires "ulid"
 requires "regex"
+
+task test, "Run canonical v0.9 tests":
+  exec "nim c -r --path:src tests/test_v09.nim"

--- a/tests/test_v09.nim
+++ b/tests/test_v09.nim
@@ -33,6 +33,30 @@ suite "StarIntel v0.9 Nim runtime":
     check restored.dataset == "test"
     check restored.schema_version == "0.9.0"
 
+  test "required relation fields are promoted":
+    let relation = newRelation(
+      "starintel:person:ada",
+      "starintel:org:analytical-engine",
+      predicate = "worked_for",
+      dataset = "test"
+    )
+    let wire = relation.dump
+    check wire["data"]["subject"].getStr == "starintel:person:ada"
+    check wire["data"]["object"].getStr == "starintel:org:analytical-engine"
+    check wire["data"]["predicate"].getStr == "worked_for"
+
+  test "domain and email required fields are promoted":
+    var domain = newDomain("example.com", "A")
+    domain.dataset = "test"
+    let domainWire = domain.dump
+    check domainWire["data"]["domain"].getStr == "example.com"
+    check domainWire["data"]["record_type"].getStr == "A"
+
+    var email = newEmail("ada", "example.com")
+    email.dataset = "test"
+    let emailWire = email.dump
+    check emailWire["data"]["address"].getStr == "ada@example.com"
+
   test "Schema.org map covers every v0.9 dtype":
     check CanonicalDtypes.len == 49
     for dtype in CanonicalDtypes:

--- a/tests/test_v09.nim
+++ b/tests/test_v09.nim
@@ -1,0 +1,39 @@
+import std/[json, unittest]
+import starintel_doc
+
+suite "StarIntel v0.9 Nim runtime":
+  test "base document emits canonical envelope":
+    var document = Document(dataset: "test", title: "Example")
+    let wire = document.dump
+    check wire["schema_version"].getStr == "0.9.0"
+    check wire["version"].getInt == 1
+    check wire["date_added"].getStr.len > 0
+    check wire["schema_org"]["@context"].getStr == "https://schema.org/"
+    check wire["schema_org"]["@id"].getStr == wire["_id"].getStr
+
+  test "legacy org fields are nested under data":
+    var org = newOrg("Example Org", "company")
+    org.dataset = "test"
+    org.country = "US"
+    let wire = org.dump
+    check wire["dtype"].getStr == "org"
+    check wire["data"]["name"].getStr == "Example Org"
+    check wire["data"]["etype"].getStr == "company"
+    check wire["schema_org"]["@type"].getStr == "Organization"
+    check not wire.hasKey("name")
+
+  test "canonical document round trip restores subtype fields":
+    var org = newOrg("Round Trip Org", "company")
+    org.dataset = "test"
+    org.reg = "123"
+    let wire = org.dump
+    let restored = load(wire, Org)
+    check restored.name == "Round Trip Org"
+    check restored.reg == "123"
+    check restored.dataset == "test"
+    check restored.schema_version == "0.9.0"
+
+  test "Schema.org map covers every v0.9 dtype":
+    check CanonicalDtypes.len == 49
+    for dtype in CanonicalDtypes:
+      check schemaOrgType(dtype).len > 0


### PR DESCRIPTION
## What changed

- migrate the Nim base document to the canonical v0.9 envelope
- preserve existing subtype object constructors while `dump()` nests subtype fields under `data`
- use ISO-8601 timestamps and integer document versions
- structure source records on the wire and restore legacy source strings on load
- add all 49 dtype aliases and Schema.org class mappings
- emit and export `schema_org` JSON-LD metadata
- add round-trip tests, CI, and documentation

## Compatibility

Existing Nim object APIs remain available. `dump()` and `load()` are the canonical v0.9 wire boundary.

## Review gate

Draft only. No merge or auto-merge until all companion runtime PRs are manually confirmed.