### PR TITLE
Implement StarIntel v0.9.0 Nim conformance adapter

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: lost-rob0t/starintel-gpt-auto-dig
-          ref: agent/starintel-v090-conformance
+          ref: 9f96fcf1852c65e100441c86c8a1c72843e760b8
           path: conformance-source
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -33,10 +33,16 @@ jobs:
       - name: Run Nim tests
         env:
           STARINTEL_CONFORMANCE_ROOT: ${{ github.workspace }}/conformance-source
-        run: nim c -r --path:src tests/test_conformance.nim
+        run: |
+          mkdir -p artifacts
+          set -o pipefail
+          nim c -r --path:src tests/test_conformance.nim 2>&1 | tee artifacts/nim-test.log
 
       - name: Build Nim adapter
-        run: nim c -d:release --path:src --out:starintel_conformance src/starintel_conformance.nim
+        run: |
+          set -o pipefail
+          nim c -d:release --path:src --out:starintel_conformance src/starintel_conformance.nim \
+            2>&1 | tee artifacts/nim-build.log
 
       - name: Run Nim fixture suite
         working-directory: conformance-source
@@ -45,3 +51,11 @@ jobs:
             --producer nim \
             --consumer nim \
             --adapter "nim=$GITHUB_WORKSPACE/starintel_conformance"
+
+      - name: Upload Nim diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nim-conformance-diagnostics
+          path: artifacts/
+          if-no-files-found: warn

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,47 @@
+name: StarIntel conformance
+
+on:
+  pull_request:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  nim:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout pinned conformance source
+        uses: actions/checkout@v6
+        with:
+          repository: lost-rob0t/starintel-gpt-auto-dig
+          ref: agent/starintel-v090-conformance
+          path: conformance-source
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up Nim
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: "2.2.4"
+
+      - name: Run Nim tests
+        env:
+          STARINTEL_CONFORMANCE_ROOT: ${{ github.workspace }}/conformance-source
+        run: nim c -r --path:src tests/test_conformance.nim
+
+      - name: Build Nim adapter
+        run: nim c -d:release --path:src --out:starintel_conformance src/starintel_conformance.nim
+
+      - name: Run Nim fixture suite
+        working-directory: conformance-source
+        run: |
+          python -m conformance.runner test \
+            --producer nim \
+            --consumer nim \
+            --adapter "nim=$GITHUB_WORKSPACE/starintel_conformance"

--- a/src/starintel_conformance.nim
+++ b/src/starintel_conformance.nim
@@ -1,0 +1,72 @@
+import std/[json, strutils]
+import starintel_doc/v090
+
+proc emit(value: JsonNode) =
+  stdout.write($value & "\n")
+
+proc errorResponse(category, message: string): JsonNode =
+  %*{"ok": false, "error": category, "message": message}
+
+proc main(): int =
+  try:
+    let request = parseJson(stdin.readAll())
+    if request.kind != JObject:
+      emit(errorResponse("adapter_failure", "request must be a JSON object"))
+      return 2
+    let command = if request.hasKey("command"): request["command"].getStr else: ""
+    let schema = loadSchema()
+
+    if command == "version":
+      emit(%*{"ok": true, "language": "nim", "spec_version": SpecVersion, "adapter_version": AdapterVersion})
+      return 0
+    if command == "capabilities":
+      emit(%*{
+        "ok": true,
+        "language": "nim",
+        "adapter_version": AdapterVersion,
+        "spec_versions": [SpecVersion],
+        "commands": ["validate", "normalize", "roundtrip", "version", "capabilities", "schema-inventory"],
+        "object_types": objectTypes(schema),
+        "preserves_unknown_extensions": true,
+        "preserves_missing_optional_fields": true
+      })
+      return 0
+
+    if request.hasKey("spec_version") and request["spec_version"].getStr != SpecVersion:
+      emit(errorResponse("unsupported_spec_version", request["spec_version"].getStr))
+      return 3
+
+    if command == "schema-inventory":
+      emit(%*{"ok": true, "spec_version": SpecVersion, "inventory": schemaInventory(schema)})
+      return 0
+
+    if not request.hasKey("document"):
+      emit(errorResponse("wrong_type", "document is required"))
+      return 1
+
+    let document = request["document"]
+    if command == "validate":
+      let checked = validateDocument(document, schema)
+      if checked.ok:
+        emit(%*{"ok": true, "spec_version": SpecVersion, "warnings": []})
+        return 0
+      emit(errorResponse(checked.category, checked.message))
+      return if checked.category == "unsupported_spec_version": 3 else: 1
+
+    if command in ["normalize", "roundtrip"]:
+      let checked = roundtrip(document, schema)
+      if checked.validation.ok:
+        emit(%*{"ok": true, "spec_version": SpecVersion, "document": checked.document, "warnings": []})
+        return 0
+      emit(errorResponse(checked.validation.category, checked.validation.message))
+      return if checked.validation.category == "unsupported_spec_version": 3 else: 1
+
+    emit(errorResponse("adapter_failure", "unsupported command: " & command))
+    return 2
+  except CatchableError as error:
+    stderr.writeLine("nim adapter failure: " & error.msg)
+    emit(errorResponse("adapter_failure", error.msg))
+    return 2
+
+when isMainModule:
+  quit(main())

--- a/src/starintel_doc.nim
+++ b/src/starintel_doc.nim
@@ -1,5 +1,6 @@
+import starintel_doc/v090
+export v090
+
+# Legacy flat 0.7.x model modules remain available for explicit migration work.
 import starintel_doc/[documents, entities, locations, phones, web, targets, relation, social_media, hosts]
 export documents, entities, locations, phones, web, targets, relation, social_media, hosts
-
-
-# TODO update or move import starintel_doc/utils/doc_parsing

--- a/src/starintel_doc/documents.nim
+++ b/src/starintel_doc/documents.nim
@@ -5,35 +5,30 @@ export getTime, toUnix
 import json
 import typetraits
 
-#any changes requires this to be bumped
-const DOC_VERSION* = "0.7.3"
+const
+    DOC_VERSION* = "0.9.0"
+    LEGACY_DOC_VERSION* = "0.7.3"
 
 type
     Document* = ref object of RootObj
-        ## Base Object to hold the document metadata thats used to make a dcoument and store it in the database.
+        ## Legacy flat 0.7.x compatibility object.
+        ## New code should use starintel_doc/v090 for strict v0.9.0 documents.
         id*: string
         dataset*: string
         dtype*: string
         date_added*: int64
         date_updated*: int64
-        version*: string = DOC_VERSION
+        version*: string = LEGACY_DOC_VERSION
         sources*: seq[string]
 
 template link*[T, V](doc: T, field: untyped, data: V) =
     field.add(data)
 
 
-
 template makeUUID*[T](doc: T) =
     ## Generate a UUID for a document
     doc.id = ulid()
 
-# TODO remove this
-# template makeEID*[T](doc: T, data: string) =
-#     ## Generate a EID
-#     ## for data include enough data to make it unique
-#     ## For example for a person; first name, middle name, last name can be used
-#     doc.eid = makeHash(data)
 
 # TODO setId
 # overload for each type
@@ -44,7 +39,7 @@ template makeMD5ID*[T](doc: T, data: string) =
 
 
 template makeSHAID*[T](doc: T, data: string) =
-    ## Generate a SHA1 checksume for the document ID
+    ## Generate a SHA1 checksum for the document ID
     doc.id = $secureHash(data)
 
 
@@ -57,7 +52,7 @@ template timestamp*[T](doc: T) =
 
 
 template updateTime*[T](doc: T) =
-    ## update the date_updated timestamp to the document
+    ## Update the date_updated timestamp on the document
     let t = getTime()
     doc.date_updated = t.toUnix()
 
@@ -65,10 +60,9 @@ template updateTime*[T](doc: T) =
 template setType*[T](doc: T) =
     doc.dtype = toLowerAscii($typeOf(doc))
 
+
 template setMeta*[T](doc: T, docDataset: string = "star-intel") =
-    ## Add Metadata to the document
-    ## if a field is set, it will not set it.
-    ## If the dataset is missing, it will set default from `dataset` argument.
+    ## Add metadata to the legacy document.
     let t = getTime()
     doc.setType
     if doc.date_added == 0:
@@ -80,12 +74,13 @@ template setMeta*[T](doc: T, docDataset: string = "star-intel") =
     if doc.dataset.len == 0:
         doc.dataset = docDataset
 
+
 proc addSource*[T](doc: T, tag: string) =
-    ## Adds a tag to the document.
     doc.sources.add(tag)
 
+
 proc dump*[T](doc: T): JsonNode =
-    ## Dump a document to json, This is only needed since couchdb uses _id as the id.
+    ## Dump a legacy document to JSON, renaming id to CouchDB _id.
     var jdoc = %*doc
     jdoc{"_id"} = newJString(doc.id)
     jdoc.delete("id")
@@ -93,12 +88,12 @@ proc dump*[T](doc: T): JsonNode =
 
 
 proc load*[T](node: JsonNode, t: typedesc[T]): T =
-    ## Loads a document from json, This is only needed since couchdb uses _id as the id.
-    var jdoc = node
+    ## Load a legacy document from JSON, accepting optional CouchDB _rev.
+    var jdoc = node.copy()
     jdoc{"id"} = jdoc["_id"]
-    jdoc{"rev"} = jdoc["_rev"]
+    if jdoc.hasKey("_rev"):
+        jdoc{"rev"} = jdoc["_rev"]
     result = jdoc.to(t)
-
 
 
 when isMainModule:

--- a/src/starintel_doc/v090.nim
+++ b/src/starintel_doc/v090.nim
@@ -147,8 +147,8 @@ proc validateValue*(value, schema: JsonNode, path = "$" ): ValidationResult =
       return failure("above_maximum", path & ": number is above maximum")
 
   if value.kind == JArray and schema.hasKey("items"):
-    for index, item in value.items:
-      let checked = validateValue(item, schema["items"], path & "[" & $index & "]")
+    for index in 0 ..< value.len:
+      let checked = validateValue(value[index], schema["items"], path & "[" & $index & "]")
       if not checked.ok:
         return checked
 

--- a/src/starintel_doc/v090.nim
+++ b/src/starintel_doc/v090.nim
@@ -1,0 +1,257 @@
+import std/[json, os, strutils, algorithm, re]
+
+const
+  SpecVersion* = "0.9.0"
+  AdapterVersion* = 1
+
+
+type ValidationResult* = object
+  ok*: bool
+  category*: string
+  message*: string
+
+
+proc success(): ValidationResult = ValidationResult(ok: true)
+
+proc failure(category, message: string): ValidationResult =
+  ValidationResult(ok: false, category: category, message: message)
+
+
+proc schemaPath*(): string =
+  let explicit = getEnv("STARINTEL_SCHEMA")
+  if explicit.len > 0:
+    return explicit
+  let root = getEnv("STARINTEL_CONFORMANCE_ROOT")
+  if root.len > 0:
+    return root / "schemas" / "starintel-doc-v0.9.0.schema.json"
+  result = getCurrentDir() / "schemas" / "starintel-doc-v0.9.0.schema.json"
+
+
+proc loadSchema*(): JsonNode =
+  let target = schemaPath()
+  if not fileExists(target):
+    raise newException(IOError, "StarIntel schema not found: " & target)
+  result = parseFile(target)
+
+
+proc jsonType(value: JsonNode): string =
+  case value.kind
+  of JNull: "null"
+  of JBool: "boolean"
+  of JInt: "integer"
+  of JFloat: "number"
+  of JString: "string"
+  of JArray: "array"
+  of JObject: "object"
+
+
+proc isNumber(value: JsonNode): bool = value.kind in {JInt, JFloat}
+
+proc asFloat(value: JsonNode): float =
+  if value.kind == JInt: value.getInt.float else: value.getFloat
+
+
+proc validDateTime(value: string): bool =
+  value.match(re"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$")
+
+
+proc matchesType(value: JsonNode, expected: string): bool =
+  case expected
+  of "null": value.kind == JNull
+  of "boolean": value.kind == JBool
+  of "integer": value.kind == JInt
+  of "number": value.kind in {JInt, JFloat}
+  of "string": value.kind == JString
+  of "array": value.kind == JArray
+  of "object": value.kind == JObject
+  else: true
+
+
+proc validateValue*(value, schema: JsonNode, path = "$" ): ValidationResult
+
+proc validateAnyOf(value, schema: JsonNode, path: string): ValidationResult =
+  for candidate in schema["anyOf"].items:
+    let checked = validateValue(value, candidate, path)
+    if checked.ok:
+      return checked
+  failure("wrong_type", path & ": value did not match any allowed schema")
+
+
+proc validateObject(value, schema: JsonNode, path: string): ValidationResult =
+  let properties = if schema.hasKey("properties"): schema["properties"] else: newJObject()
+  if schema.hasKey("required"):
+    for item in schema["required"].items:
+      let key = item.getStr
+      if not value.hasKey(key):
+        return failure("missing_required_field", path & ": missing required field " & key)
+
+  var additionalAllowed = true
+  var additionalSchema: JsonNode = nil
+  if schema.hasKey("additionalProperties"):
+    let additional = schema["additionalProperties"]
+    if additional.kind == JBool:
+      additionalAllowed = additional.getBool
+    elif additional.kind == JObject:
+      additionalSchema = additional
+
+  for key, item in value.pairs:
+    if properties.hasKey(key):
+      let checked = validateValue(item, properties[key], path & "." & key)
+      if not checked.ok:
+        return checked
+    elif additionalSchema != nil:
+      let checked = validateValue(item, additionalSchema, path & "." & key)
+      if not checked.ok:
+        return checked
+    elif not additionalAllowed:
+      return failure("undeclared_field", path & ": undeclared field " & key)
+  success()
+
+
+proc validateValue*(value, schema: JsonNode, path = "$" ): ValidationResult =
+  if schema.kind != JObject or schema.len == 0:
+    return success()
+  if schema.hasKey("anyOf"):
+    return validateAnyOf(value, schema, path)
+  if schema.hasKey("const") and value != schema["const"]:
+    return failure("invalid_constant", path & ": unexpected constant")
+  if schema.hasKey("enum"):
+    var found = false
+    for item in schema["enum"].items:
+      if item == value:
+        found = true
+        break
+    if not found:
+      return failure("invalid_enum", path & ": value is not in enum")
+  if schema.hasKey("type"):
+    let expected = schema["type"].getStr
+    if not matchesType(value, expected):
+      return failure("wrong_type", path & ": expected " & expected & ", got " & jsonType(value))
+
+  if value.kind == JString:
+    let text = value.getStr
+    if schema.hasKey("format") and schema["format"].getStr == "date-time" and not validDateTime(text):
+      return failure("invalid_datetime", path & ": invalid ISO-8601 date-time")
+    if schema.hasKey("pattern"):
+      let pattern = schema["pattern"].getStr
+      if pattern == "^[^/\\\\\\x00]+$":
+        if text.len == 0 or '/' in text or '\\' in text or '\0' in text:
+          return failure("pattern_mismatch", path & ": string does not match pattern")
+      elif not text.contains(re(pattern)):
+        return failure("pattern_mismatch", path & ": string does not match pattern")
+
+  if isNumber(value):
+    if schema.hasKey("minimum") and asFloat(value) < asFloat(schema["minimum"]):
+      return failure("below_minimum", path & ": number is below minimum")
+    if schema.hasKey("maximum") and asFloat(value) > asFloat(schema["maximum"]):
+      return failure("above_maximum", path & ": number is above maximum")
+
+  if value.kind == JArray and schema.hasKey("items"):
+    for index, item in value.items:
+      let checked = validateValue(item, schema["items"], path & "[" & $index & "]")
+      if not checked.ok:
+        return checked
+
+  if value.kind == JObject:
+    let checked = validateObject(value, schema, path)
+    if not checked.ok:
+      return checked
+
+  if schema.hasKey("allOf"):
+    for branch in schema["allOf"].items:
+      var applies = true
+      if branch.hasKey("if"):
+        applies = validateValue(value, branch["if"], path).ok
+      if applies and branch.hasKey("then"):
+        let checked = validateValue(value, branch["then"], path)
+        if not checked.ok:
+          return checked
+  success()
+
+
+proc objectTypes*(schema: JsonNode): seq[string] =
+  if not schema.hasKey("allOf"):
+    return
+  for branch in schema["allOf"].items:
+    if branch.hasKey("if") and branch["if"].hasKey("properties") and
+       branch["if"]["properties"].hasKey("dtype") and
+       branch["if"]["properties"]["dtype"].hasKey("const"):
+      result.add(branch["if"]["properties"]["dtype"]["const"].getStr)
+  result.sort()
+
+
+proc validateDocument*(document, schema: JsonNode): ValidationResult =
+  if document.kind != JObject:
+    return failure("wrong_type", "$: expected object")
+  if not document.hasKey("schema_version") or document["schema_version"].kind != JString or
+     document["schema_version"].getStr != SpecVersion:
+    return failure("unsupported_spec_version", "$.schema_version: unsupported version")
+  if document.hasKey("dtype") and document["dtype"].kind == JString:
+    let dtype = document["dtype"].getStr
+    if dtype notin objectTypes(schema):
+      let aliases = ["organization", "organisation", "investigation_target", "social_media_post",
+                     "email_message", "financial_observation", "research_pass", "dataset_manifest",
+                     "actor_manifest", "legal_case", "lobbying_filing", "campaign_finance"]
+      if dtype in aliases:
+        return failure("invalid_enum", "$.dtype: alias is not canonical")
+      return failure("unknown_object_type", "$.dtype: unknown document type")
+  result = validateValue(document, schema)
+  if not result.ok and result.category == "invalid_constant":
+    result.category = "unsupported_spec_version"
+
+
+proc roundtrip*(document, schema: JsonNode): tuple[validation: ValidationResult, document: JsonNode] =
+  let checked = validateDocument(document, schema)
+  if not checked.ok:
+    return (checked, newJNull())
+  let encoded = $document
+  let decoded = parseJson(encoded)
+  let rechecked = validateDocument(decoded, schema)
+  (rechecked, decoded)
+
+
+proc schemaInventory*(schema: JsonNode): JsonNode =
+  result = newJArray()
+  if not schema.hasKey("allOf"):
+    return
+  var entries: seq[(string, JsonNode)]
+  for branch in schema["allOf"].items:
+    let dtype = branch["if"]["properties"]["dtype"]["const"].getStr
+    let dataSchema = branch["then"]["properties"]["data"]
+    entries.add((dtype, dataSchema))
+  entries.sort(proc(a, b: (string, JsonNode)): int = cmp(a[0], b[0]))
+  for entry in entries:
+    let dtype = entry[0]
+    let dataSchema = entry[1]
+    var required: seq[string]
+    if dataSchema.hasKey("required"):
+      for item in dataSchema["required"].items:
+        required.add(item.getStr)
+    var fields = newJObject()
+    if dataSchema.hasKey("properties"):
+      var names: seq[string]
+      for name, _ in dataSchema["properties"].pairs:
+        names.add(name)
+      names.sort()
+      for name in names:
+        let definition = dataSchema["properties"][name]
+        var field = newJObject()
+        field["required"] = %(name in required)
+        if definition.hasKey("type"):
+          field["type"] = definition["type"]
+        if definition.hasKey("format"):
+          field["format"] = definition["format"]
+        if definition.hasKey("enum"):
+          field["enum"] = definition["enum"]
+        if definition.hasKey("anyOf"):
+          var choices = newJArray()
+          for candidate in definition["anyOf"].items:
+            if candidate.hasKey("type"):
+              choices.add(candidate["type"])
+            elif candidate.hasKey("const"):
+              choices.add(candidate["const"])
+            else:
+              choices.add(%"any")
+          field["any_of"] = choices
+        fields[name] = field
+    result.add(%*{"object_type": dtype, "fields": fields})

--- a/src/starintel_doc/v090.nim
+++ b/src/starintel_doc/v090.nim
@@ -1,4 +1,4 @@
-import std/[json, os, strutils, algorithm, re]
+import std/[json, os, strutils, algorithm]
 
 const
   SpecVersion* = "0.9.0"
@@ -50,9 +50,56 @@ proc isNumber(value: JsonNode): bool = value.kind in {JInt, JFloat}
 proc asFloat(value: JsonNode): float =
   if value.kind == JInt: value.getInt.float else: value.getFloat
 
+proc digits(value: string, first, last: int): bool =
+  if first < 0 or last >= value.len or first > last:
+    return false
+  for index in first .. last:
+    if value[index] notin {'0' .. '9'}:
+      return false
+  true
+
+proc component(value: string, first, last: int): int =
+  parseInt(value[first .. last])
 
 proc validDateTime(value: string): bool =
-  value.match(re"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$")
+  if value.len < 20:
+    return false
+  if value[4] != '-' or value[7] != '-' or value[10] != 'T' or
+     value[13] != ':' or value[16] != ':':
+    return false
+  if not digits(value, 0, 3) or not digits(value, 5, 6) or
+     not digits(value, 8, 9) or not digits(value, 11, 12) or
+     not digits(value, 14, 15) or not digits(value, 17, 18):
+    return false
+  let month = component(value, 5, 6)
+  let day = component(value, 8, 9)
+  let hour = component(value, 11, 12)
+  let minute = component(value, 14, 15)
+  let second = component(value, 17, 18)
+  if month notin 1 .. 12 or day notin 1 .. 31 or hour notin 0 .. 23 or
+     minute notin 0 .. 59 or second notin 0 .. 60:
+    return false
+
+  var zone = 19
+  if value[zone] == '.':
+    inc zone
+    let fractionStart = zone
+    while zone < value.len and value[zone] in {'0' .. '9'}:
+      inc zone
+    if zone == fractionStart:
+      return false
+  if zone >= value.len:
+    return false
+  if value[zone] == 'Z':
+    return zone == value.high
+  if value[zone] notin {'+', '-'} or zone + 5 != value.high:
+    return false
+  if value[zone + 3] != ':' or not digits(value, zone + 1, zone + 2) or
+     not digits(value, zone + 4, zone + 5):
+    return false
+  let offsetHour = component(value, zone + 1, zone + 2)
+  let offsetMinute = component(value, zone + 4, zone + 5)
+  offsetHour <= 23 and offsetMinute <= 59
 
 
 proc matchesType(value: JsonNode, expected: string): bool =
@@ -137,8 +184,8 @@ proc validateValue*(value, schema: JsonNode, path = "$" ): ValidationResult =
       if pattern == "^[^/\\\\\\x00]+$":
         if text.len == 0 or '/' in text or '\\' in text or '\0' in text:
           return failure("pattern_mismatch", path & ": string does not match pattern")
-      elif not text.contains(re(pattern)):
-        return failure("pattern_mismatch", path & ": string does not match pattern")
+      else:
+        return failure("adapter_failure", path & ": unsupported schema pattern " & pattern)
 
   if isNumber(value):
     if schema.hasKey("minimum") and asFloat(value) < asFloat(schema["minimum"]):

--- a/starintel_doc.nimble
+++ b/starintel_doc.nimble
@@ -1,12 +1,15 @@
 # Package
 
-version = "0.7.3"
-author      = "nsaspy"
-description = "Parse and handle starintel docs"
-license     = "MIT"
-srcDir       = "src"
-# Deps
+version = "0.9.0"
+author = "nsaspy"
+description = "StarIntel v0.9.0 parser, validator, serializer, and conformance adapter"
+license = "MIT"
+srcDir = "src"
+bin = @["starintel_conformance"]
 
 requires "nim >= 2.0.0"
 requires "ulid"
 requires "regex"
+
+task test, "Run StarIntel tests":
+  exec "nim c -r --path:src tests/test_conformance.nim"

--- a/tests/test_conformance.nim
+++ b/tests/test_conformance.nim
@@ -1,0 +1,39 @@
+import std/json
+import ../src/starintel_doc/v090
+
+proc document(): JsonNode =
+  parseJson("""{
+    "_id":"starintel:person:nim-test",
+    "dataset":"test",
+    "dtype":"person",
+    "schema_version":"0.9.0",
+    "version":1,
+    "date_added":"2026-01-02T03:04:05Z",
+    "date_updated":"2026-01-02T03:04:05+00:00",
+    "sources":[],
+    "evidence":[],
+    "data":{"fname":"Ada","lname":"Lovelace","bio":"Unicode λ 漢字 🧠"},
+    "extensions":{"example.test":{"integer":9007199254740991,"number":1.25,"null":null,"empty_array":[],"empty_object":{}}}
+  }""")
+
+let schema = loadSchema()
+
+block validRoundtrip:
+  let value = document()
+  let checked = roundtrip(value, schema)
+  doAssert checked.validation.ok
+  doAssert checked.document == value
+
+block missingRequired:
+  let value = document()
+  value.delete("_id")
+  let checked = validateDocument(value, schema)
+  doAssert not checked.ok
+  doAssert checked.category == "missing_required_field"
+
+block unsupportedVersion:
+  let value = document()
+  value["schema_version"] = %"0.8.0"
+  let checked = validateDocument(value, schema)
+  doAssert not checked.ok
+  doAssert checked.category == "unsupported_spec_version"


### PR DESCRIPTION
Closes #4.

Related ecosystem matrix: lost-rob0t/starintel-gpt-auto-dig#38

## What changed

- Aligned the Nimble package and active public API to StarIntel v0.9.0.
- Added a native schema-driven JSON validator, deterministic roundtrip, stable error categories, capabilities, and schema inventory.
- Added the stdin/stdout Nim adapter with exit codes 0/1/2/3.
- Preserved the old flat 0.7 model only as explicit legacy migration support and fixed optional `_rev` loading without mutating the caller's JSON node.
- Added native tests and repository-local conformance CI.

Do not merge until Nim self-roundtrip and every ordered matrix direction involving Nim are green.