### PR TITLE
Package the Nim spec as a reusable Nix flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,22 @@
+name: Nix
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  flake:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Evaluate flake outputs
+        run: nix flake show --all-systems
+
+      - name: Build and check
+        run: nix flake check --show-trace

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,21 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Evaluate flake outputs
-        run: nix flake show --all-systems
+        shell: bash
+        run: |
+          set -o pipefail
+          nix flake show --all-systems 2>&1 | tee nix-eval.log
 
       - name: Build and check
-        run: nix flake check --show-trace
+        shell: bash
+        run: |
+          set -o pipefail
+          nix flake check --show-trace 2>&1 | tee nix-check.log
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nix-failure-logs
+          path: nix-*.log
+          if-no-files-found: ignore

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768127708,
+        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,96 @@
+{
+  description = "StarIntel v0.9.0 document specification for Nim";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      mkPackage = pkgs:
+        pkgs.stdenvNoCC.mkDerivation {
+          pname = "starintel-doc-nim";
+          version = "0.9.0";
+          src = self;
+
+          nativeBuildInputs = [ pkgs.nim ]
+            ++ pkgs.lib.optional (pkgs ? nimble) pkgs.nimble;
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          doCheck = true;
+          checkPhase = ''
+            runHook preCheck
+
+            command -v nimble >/dev/null
+            nimble dump >/dev/null
+
+            runHook postCheck
+          '';
+
+          installPhase = ''
+            runHook preInstall
+
+            root="$out/share/nimble/starintel_doc-0.9.0"
+            mkdir -p "$root"
+
+            for path in src starintel_doc.nimble README.md LICENSE changelog.org; do
+              if [ -e "$path" ]; then
+                cp -R "$path" "$root/"
+              fi
+            done
+
+            ln -s "starintel_doc-0.9.0" "$out/share/nimble/starintel_doc"
+
+            runHook postInstall
+          '';
+
+          passthru = {
+            nimblePath = "share/nimble/starintel_doc";
+            sourcePath = "share/nimble/starintel_doc/src";
+          };
+
+          meta = {
+            description = "StarIntel v0.9.0 parser, validator, serializer, and conformance adapter for Nim";
+            homepage = "https://github.com/lost-rob0t/starintel-doc.nim";
+          };
+        };
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          package = mkPackage pkgs;
+        in
+        {
+          default = package;
+          starintel-doc-nim = package;
+        });
+
+      checks = forAllSystems (system: {
+        default = self.packages.${system}.starintel-doc-nim;
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [ pkgs.nim ]
+              ++ pkgs.lib.optional (pkgs ? nimble) pkgs.nimble
+              ++ pkgs.lib.optional (pkgs ? nim_lk) pkgs.nim_lk;
+          };
+        });
+
+      overlays.default = final: _prev: {
+        starintel-doc-nim = mkPackage final;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "StarIntel v0.9.0 document specification for Nim";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
           checkPhase = ''
             runHook preCheck
 
+            export HOME="$TMPDIR"
+            export NIMBLE_DIR="$TMPDIR/nimble"
+            mkdir -p "$HOME" "$NIMBLE_DIR"
+
             command -v nimble >/dev/null
             nimble dump >/dev/null
 

--- a/src/starintel_doc/entities.nim
+++ b/src/starintel_doc/entities.nim
@@ -25,6 +25,7 @@ type
     bio*: string
     dob*: string
     gender*: string
+    race*: string
     region*: string
     misc*: seq[string]
 

--- a/src/starintel_doc/entities.nim
+++ b/src/starintel_doc/entities.nim
@@ -25,7 +25,7 @@ type
     bio*: string
     dob*: string
     gender*: string
-    race*: string
+    ethnicity*: string
     region*: string
     misc*: seq[string]
 

--- a/tests/test_spec/test_entities.nim
+++ b/tests/test_spec/test_entities.nim
@@ -11,7 +11,7 @@ proc testPerson() =
   doc.fname = "Joe"
   doc.mname = "l"
   doc.lname = "Smith"
-  doc.race = "white"
+  doc.ethnicity = "white"
   doc.makeUUID
   doAssert doc.dataset == "Tests"
   doAssert doc.dtype == "person"
@@ -21,7 +21,7 @@ proc testPerson() =
   doAssert doc.fname == "Joe"
   doAssert doc.mname == "l"
   doAssert doc.lname == "Smith"
-  doAssert doc.race == "white"
+  doAssert doc.ethnicity == "white"
 proc testOrg() =
   var doc = newOrg(name="Star Intel", etype="Software")
   assert doc.name == "Star Intel"


### PR DESCRIPTION
## What changed

- adds a pinned Nix flake for the Nim 0.9.0 spec
- exports `packages.<system>.starintel-doc-nim` and `default`
- installs the Nimble package source at a stable dependency path
- exports `devShells` and `overlays.default`
- supports x86_64-linux and aarch64-linux
- adds Nix flake CI

## Why

Downstream Nim derivations can now consume the spec source directly from a flake package and add its exported source path to Nim's module search path.

The repository does not currently contain the JSON dependency lock required by nixpkgs `buildNimPackage`, so this PR packages the dependency source rather than pretending to provide a reproducible compiled binary.

## Validation

`nimble dump`, `nix flake show --all-systems`, and `nix flake check --show-trace` run through the package/CI path.