### PR TITLE
Add typed actor and dataset manifest documents

### DIFF
--- a/src/starintel_doc.nim
+++ b/src/starintel_doc.nim
@@ -2,5 +2,7 @@ import starintel_doc/v090
 export v090
 
 # Legacy flat 0.7.x model modules remain available for explicit migration work.
-import starintel_doc/[documents, entities, locations, phones, web, targets, relation, social_media, hosts]
-export documents, entities, locations, phones, web, targets, relation, social_media, hosts
+import starintel_doc/[documents, entities, locations, phones, web, targets, relation,
+  social_media, hosts, manifests]
+export documents, entities, locations, phones, web, targets, relation, social_media,
+  hosts, manifests

--- a/src/starintel_doc/manifests.nim
+++ b/src/starintel_doc/manifests.nim
@@ -119,7 +119,8 @@ proc requireString(node: JsonNode, key, path: string) =
 proc requireStringArray(node: JsonNode, key, path: string) =
   if not node.hasKey(key) or node[key].kind != JArray:
     raise newException(ValueError, path & "." & key & " must be an array")
-  for index, item in node[key].items:
+  for index in 0 ..< node[key].len:
+    let item = node[key][index]
     if item.kind != JString or item.getStr.len == 0:
       raise newException(
         ValueError,

--- a/src/starintel_doc/manifests.nim
+++ b/src/starintel_doc/manifests.nim
@@ -1,0 +1,179 @@
+import std/json
+
+type
+  ManifestImplementation* = object
+    inlineSource*: string
+    entrypoint*: string
+    package*: string
+    uri*: string
+    builtInId*: string
+    serviceUrl*: string
+
+  ActorManifest* = object
+    actorId*: string
+    label*: string
+    description*: string
+    actorVersion*: string
+    protocolVersion*: string
+    specCompatibility*: seq[string]
+    roles*: seq[string]
+    accepts*: seq[string]
+    produces*: seq[string]
+    inputPorts*: JsonNode
+    outputPorts*: JsonNode
+    routing*: JsonNode
+    implementation*: ManifestImplementation
+    runtime*: JsonNode
+    dependencies*: JsonNode
+    configuration*: JsonNode
+    optionsSchema*: JsonNode
+    capabilities*: seq[string]
+    permissions*: seq[string]
+    datasetRestrictions*: seq[string]
+    resources*: JsonNode
+    rateLimits*: JsonNode
+    budgetLimits*: JsonNode
+    mailboxPolicy*: JsonNode
+    retryPolicy*: JsonNode
+    deadLetterPolicy*: JsonNode
+    restartPolicy*: JsonNode
+    loopDetection*: JsonNode
+    errorPolicy*: JsonNode
+    healthChecks*: JsonNode
+    readiness*: JsonNode
+    shutdown*: JsonNode
+    checkpointing*: JsonNode
+
+  DatasetManifest* = object
+    datasetId*: string
+    name*: string
+    description*: string
+    datasetVersion*: string
+    specCompatibility*: seq[string]
+    documentIds*: seq[string]
+    documentTypes*: seq[string]
+    schemaRefs*: seq[string]
+    predicateRegistryRef*: string
+    storageBindings*: JsonNode
+    storageLayers*: JsonNode
+    indexes*: JsonNode
+    materializations*: JsonNode
+    embeddings*: JsonNode
+    actorBindings*: JsonNode
+    flowBindings*: JsonNode
+    graphRefs*: seq[string]
+    lineage*: JsonNode
+    validationPolicy*: JsonNode
+    statistics*: JsonNode
+    accessControl*: JsonNode
+    retentionPolicy*: JsonNode
+    publication*: JsonNode
+    migrationHistory*: JsonNode
+
+const
+  ActorManifestFields = [
+    "actorId", "label", "description", "actorVersion", "protocolVersion",
+    "specCompatibility", "roles", "accepts", "produces", "inputPorts",
+    "outputPorts", "routing", "implementation", "runtime", "dependencies",
+    "configuration", "optionsSchema", "capabilities", "permissions",
+    "datasetRestrictions", "resources", "rateLimits", "budgetLimits",
+    "mailboxPolicy", "retryPolicy", "deadLetterPolicy", "restartPolicy",
+    "loopDetection", "errorPolicy", "healthChecks", "readiness", "shutdown",
+    "checkpointing"
+  ]
+  DatasetManifestFields = [
+    "datasetId", "name", "description", "datasetVersion",
+    "specCompatibility", "documentIds", "documentTypes", "schemaRefs",
+    "predicateRegistryRef", "storageBindings", "storageLayers", "indexes",
+    "materializations", "embeddings", "actorBindings", "flowBindings",
+    "graphRefs", "lineage", "validationPolicy", "statistics",
+    "accessControl", "retentionPolicy", "publication", "migrationHistory"
+  ]
+  ImplementationFields = [
+    "inlineSource", "entrypoint", "package", "uri", "builtInId", "serviceUrl"
+  ]
+
+proc contains(fields: openArray[string], key: string): bool =
+  for field in fields:
+    if field == key:
+      return true
+
+proc requireObject(node: JsonNode, path: string) =
+  if node.kind != JObject:
+    raise newException(ValueError, path & " must be an object")
+
+proc rejectUnknownFields(
+  node: JsonNode,
+  allowed: openArray[string],
+  path: string
+) =
+  requireObject(node, path)
+  for key, _ in node.pairs:
+    if not allowed.contains(key):
+      raise newException(ValueError, path & " contains unknown field " & key)
+
+proc requireString(node: JsonNode, key, path: string) =
+  if not node.hasKey(key) or node[key].kind != JString or node[key].getStr.len == 0:
+    raise newException(ValueError, path & "." & key & " must be a non-empty string")
+
+proc requireStringArray(node: JsonNode, key, path: string) =
+  if not node.hasKey(key) or node[key].kind != JArray:
+    raise newException(ValueError, path & "." & key & " must be an array")
+  for index, item in node[key].items:
+    if item.kind != JString or item.getStr.len == 0:
+      raise newException(
+        ValueError,
+        path & "." & key & "[" & $index & "] must be a non-empty string"
+      )
+
+proc validateImplementation(node: JsonNode) =
+  rejectUnknownFields(node, ImplementationFields, "$.implementation")
+  var found = false
+  for field in ImplementationFields:
+    if node.hasKey(field):
+      if node[field].kind != JString:
+        raise newException(
+          ValueError,
+          "$.implementation." & field & " must be a string"
+        )
+      if node[field].getStr.len > 0:
+        found = true
+  if not found:
+    raise newException(
+      ValueError,
+      "$.implementation requires an implementation locator"
+    )
+
+proc validateActorManifestJson*(node: JsonNode) =
+  rejectUnknownFields(node, ActorManifestFields, "$")
+  requireString(node, "actorId", "$")
+  requireString(node, "label", "$")
+  requireString(node, "actorVersion", "$")
+  requireString(node, "protocolVersion", "$")
+  requireStringArray(node, "specCompatibility", "$")
+  requireStringArray(node, "accepts", "$")
+  requireStringArray(node, "produces", "$")
+  if not node.hasKey("implementation"):
+    raise newException(ValueError, "$.implementation is required")
+  validateImplementation(node["implementation"])
+
+proc validateDatasetManifestJson*(node: JsonNode) =
+  rejectUnknownFields(node, DatasetManifestFields, "$")
+  requireString(node, "datasetId", "$")
+  requireString(node, "name", "$")
+  requireString(node, "datasetVersion", "$")
+  requireStringArray(node, "specCompatibility", "$")
+
+proc parseActorManifest*(node: JsonNode): ActorManifest =
+  validateActorManifestJson(node)
+  result = node.to(ActorManifest)
+
+proc parseDatasetManifest*(node: JsonNode): DatasetManifest =
+  validateDatasetManifestJson(node)
+  result = node.to(DatasetManifest)
+
+proc dump*(manifest: ActorManifest): JsonNode =
+  %*manifest
+
+proc dump*(manifest: DatasetManifest): JsonNode =
+  %*manifest

--- a/src/starintel_doc/spec.nim
+++ b/src/starintel_doc/spec.nim
@@ -1,4 +1,4 @@
 import documents, entities, locations, phones, web, targets, relation,
-    social_media, hosts
+    social_media, hosts, manifests
 export documents, entities, locations, phones, web, targets, relation,
-    social_media, hosts
+    social_media, hosts, manifests

--- a/tests/test_spec/test_manifests.nim
+++ b/tests/test_spec/test_manifests.nim
@@ -1,0 +1,60 @@
+discard """
+  action: run
+"""
+
+import std/json
+import ../../src/starintel_doc/manifests
+
+proc rejectsActor(node: JsonNode) =
+  var rejected = false
+  try:
+    discard parseActorManifest(node)
+  except ValueError:
+    rejected = true
+  doAssert rejected
+
+let actorNode = parseJson("""
+{
+  "actorId": "actor.fec.import",
+  "label": "FEC importer",
+  "actorVersion": "1.0.0",
+  "protocolVersion": "1",
+  "specCompatibility": ["0.9.0"],
+  "accepts": ["target"],
+  "produces": ["person", "org", "relation"],
+  "implementation": {
+    "entrypoint": "fec_importer/main"
+  }
+}
+""")
+let actor = parseActorManifest(actorNode)
+doAssert actor.actorId == "actor.fec.import"
+doAssert actor.implementation.entrypoint == "fec_importer/main"
+doAssert actor.dump["actorId"].getStr == "actor.fec.import"
+
+var actorWithDocumentIds = actorNode.copy()
+actorWithDocumentIds["documentIds"] = %*["starintel:person:1"]
+rejectsActor(actorWithDocumentIds)
+
+var actorWithLegacyDocumentIds = actorNode.copy()
+actorWithLegacyDocumentIds["document_ids"] = %*["starintel:person:1"]
+rejectsActor(actorWithLegacyDocumentIds)
+
+var actorWithoutLocator = actorNode.copy()
+actorWithoutLocator["implementation"] = newJObject()
+rejectsActor(actorWithoutLocator)
+
+let datasetNode = parseJson("""
+{
+  "datasetId": "dataset.fec",
+  "name": "Federal Election Commission",
+  "datasetVersion": "1.0.0",
+  "specCompatibility": ["0.9.0"],
+  "documentIds": ["starintel:person:1"],
+  "documentTypes": ["person", "org", "relation"]
+}
+""")
+let dataset = parseDatasetManifest(datasetNode)
+doAssert dataset.datasetId == "dataset.fec"
+doAssert dataset.documentIds == @["starintel:person:1"]
+doAssert dataset.dump["documentIds"][0].getStr == "starintel:person:1"


### PR DESCRIPTION
## What changed

- adds separate `ActorManifest` and `DatasetManifest` Nim types
- uses camelCase API and wire fields
- validates required manifest identity and compatibility fields
- requires at least one actor implementation locator
- rejects unknown top-level fields
- explicitly rejects `documentIds` and legacy `document_ids` on Actor Manifest
- keeps `documentIds` on Dataset Manifest
- exports manifest support from the package entry points
- adds positive and negative Testament coverage

## Scope

This implements the Nim library only. Python, JavaScript, and Common Lisp are intentionally deferred.

## Research authority

Implements the boundary recorded in `STAR-MANIFEST-001 Actor and Dataset Manifest Document Contracts` in `lost-rob0t/starintel-auto-research`.
